### PR TITLE
Don't dismiss selection if Windows key was also pressed

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1090,7 +1090,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                                        const WORD scanCode,
                                        const ControlKeyStates modifiers,
                                        const bool keyDown)
-    {
+    {    
         // When there is a selection active, escape should clear it and NOT flow through
         // to the terminal. With any other keypress, it should clear the selection AND
         // flow through to the terminal.
@@ -1100,14 +1100,18 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // selection.
         if (_terminal->IsSelectionActive() && !KeyEvent::IsModifierKey(vkey) && vkey != VK_SNAPSHOT)
         {
-            _terminal->ClearSelection();
-            _renderer->TriggerSelection();
-
+            // GH#8791 - don't dismiss selection if Windows key was also pressed as a key-combination.
+            if (!(GetKeyState(VK_LWIN) & 0x8000) && !(GetKeyState(VK_RWIN) & 0x8000))
+            {
+                _terminal->ClearSelection();
+                _renderer->TriggerSelection();
+            }
+            
             if (vkey == VK_ESCAPE)
             {
                 return true;
             }
-        }
+        }   
 
         if (vkey == VK_ESCAPE ||
             vkey == VK_RETURN)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1106,7 +1106,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 _terminal->ClearSelection();
                 _renderer->TriggerSelection();
             }
-            
+
             if (vkey == VK_ESCAPE)
             {
                 return true;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1100,8 +1100,14 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // selection.
         if (_terminal->IsSelectionActive() && !KeyEvent::IsModifierKey(vkey) && vkey != VK_SNAPSHOT)
         {
+            CoreWindow window = CoreWindow::GetForCurrentThread();
+            const auto leftWinKeyState = window.GetKeyState(VirtualKey::LeftWindows);
+            const auto rightWinKeyState = window.GetKeyState(VirtualKey::RightWindows);
+            const auto isLeftWinKeyDown = WI_IsFlagSet(leftWinKeyState, CoreVirtualKeyStates::Down);
+            const auto isRightWinKeyDown = WI_IsFlagSet(rightWinKeyState, CoreVirtualKeyStates::Down);
+
             // GH#8791 - don't dismiss selection if Windows key was also pressed as a key-combination.
-            if (!(GetKeyState(VK_LWIN) & 0x8000) && !(GetKeyState(VK_RWIN) & 0x8000))
+            if (!isLeftWinKeyDown && !isRightWinKeyDown)
             {
                 _terminal->ClearSelection();
                 _renderer->TriggerSelection();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1090,7 +1090,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                                        const WORD scanCode,
                                        const ControlKeyStates modifiers,
                                        const bool keyDown)
-    {    
+    {
         // When there is a selection active, escape should clear it and NOT flow through
         // to the terminal. With any other keypress, it should clear the selection AND
         // flow through to the terminal.
@@ -1111,7 +1111,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             {
                 return true;
             }
-        }   
+        }
 
         if (vkey == VK_ESCAPE ||
             vkey == VK_RETURN)


### PR DESCRIPTION
Aims to fix #8791

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If Windows key was pressed as a part of a key combination, then selection is not cleared.
Prior to this PR, a selection was dismissed if a user pressed `Windows` + `Shift` + `S` keys to invoke the _Capture & Annotate_ tool.
This PR adds an exception for not clearing selection when either of the two Windows keys are pressed as part of a key combination.
It was tested manually by trying to reproduce the issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #8791
* [x ] CLA signed.
* [x ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #8791

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Build Terminal.
2. Write anything & make a selection.
3. Press `Windows`+ `Shift` + `S` keys.
4. The _Capture & Annotate_ tool appears but the selection made in step 2 isn't dismissed (doesn't disappear).
